### PR TITLE
Update pact-consumer-swift version

### DIFF
--- a/documentation/swift.md
+++ b/documentation/swift.md
@@ -1,5 +1,5 @@
 # Swift / Objective-C
 
-Pact for [Swift and Objective-C](https://github.com/DiUS/pact-consumer-swift) is currently in *beta* targeting Pact specification 1.1. 
+Pact for [Swift and Objective-C](https://github.com/DiUS/pact-consumer-swift) is currently targeting Pact specification v2. 
 
 Head to the [website](https://github.com/DiUS/pact-consumer-swift) to get started with Swift and Objective-C.


### PR DESCRIPTION
[pact-consumer-swift](https://github.com/DiUS/pact-consumer-swift) is apparently now implemeting Pact specification v2, and does not state anything about beta anymore! :-)